### PR TITLE
fix: Restore broken slider functionality on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
                 </div>
                 <div class="card p-6 flex flex-col items-center text-center">
                     <h3 class="text-lg font-semibold text-gray-500 mb-2">September 2027</h3>
-                    <p class="text-2xl font-bold text-red-600">A crazy <strong>50×</strong> faster (Agent-4 takes off)</p>
+                    <p class="text-2xl font-bold text-red-600">A crazy <strong><span id="summary-multiplier">50x</span></strong> faster (Agent-4 takes off)</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
This commit fixes a bug where the interactive sliders on the main page (`index.html`) were not updating.

The previous refactor of the page content accidentally removed an element with the ID `summary-multiplier`. This ID was required by the page's JavaScript to update a text field when a slider was moved. The missing ID caused a script error, which halted all slider-related updates.

This patch re-introduces the `summary-multiplier` ID by wrapping the dynamic number in the 'September 2027' card within a `<span>` element. This restores the script's target and allows the sliders to function as intended.